### PR TITLE
Update eslint config

### DIFF
--- a/config/eslint/package.json
+++ b/config/eslint/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",
+    "@next/eslint-plugin-next": "^15.2.1",
     "@typescript-eslint/eslint-plugin": "^8.24.1",
     "@workspace/typescript": "workspace:*",
     "eslint": "^9.21.0",

--- a/config/eslint/src/index.ts
+++ b/config/eslint/src/index.ts
@@ -5,6 +5,8 @@ import pluginReact from "eslint-plugin-react";
 import globals from "globals";
 import turboPlugin from "eslint-plugin-turbo";
 import tseslint from "typescript-eslint";
+// @ts-expect-error No types for eslint-plugin-next.
+import pluginNext from "@next/eslint-plugin-next";
 
 export const eslintConfig: Linter.Config[] = [
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
@@ -15,6 +17,7 @@ export const eslintConfig: Linter.Config[] = [
   {
     plugins: {
       "@typescript-eslint": tsPlugin,
+      "@next/next": pluginNext,
       react: pluginReact,
       turbo: turboPlugin,
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,9 @@ importers:
       '@eslint/js':
         specifier: ^9.21.0
         version: 9.21.0
+      '@next/eslint-plugin-next':
+        specifier: ^15.2.1
+        version: 15.2.1
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.24.1
         version: 8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2)
@@ -1394,6 +1397,9 @@ packages:
 
   '@next/env@15.2.1':
     resolution: {integrity: sha512-JmY0qvnPuS2NCWOz2bbby3Pe0VzdAQ7XpEB6uLIHmtXNfAsAO0KLQLkuAoc42Bxbo3/jMC3dcn9cdf+piCcG2Q==}
+
+  '@next/eslint-plugin-next@15.2.1':
+    resolution: {integrity: sha512-6ppeToFd02z38SllzWxayLxjjNfzvc7Wm07gQOKSLjyASvKcXjNStZrLXMHuaWkhjqxe+cnhb2uzfWXm1VEj/Q==}
 
   '@next/swc-darwin-arm64@15.2.1':
     resolution: {integrity: sha512-aWXT+5KEREoy3K5AKtiKwioeblmOvFFjd+F3dVleLvvLiQ/mD//jOOuUcx5hzcO9ISSw4lrqtUPntTpK32uXXQ==}
@@ -3509,6 +3515,10 @@ packages:
 
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+
+  fast-glob@3.3.1:
+    resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
+    engines: {node: '>=8.6.0'}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -7518,6 +7528,10 @@ snapshots:
 
   '@next/env@15.2.1': {}
 
+  '@next/eslint-plugin-next@15.2.1':
+    dependencies:
+      fast-glob: 3.3.1
+
   '@next/swc-darwin-arm64@15.2.1':
     optional: true
 
@@ -9971,6 +9985,14 @@ snapshots:
   fast-diff@1.3.0: {}
 
   fast-fifo@1.3.2: {}
+
+  fast-glob@3.3.1:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
 
   fast-glob@3.3.3:
     dependencies:


### PR DESCRIPTION
fix: No warning message of next lint when building Next.js project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced development tooling with improved Next.js linting support to ensure robust code quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->